### PR TITLE
Fix persistent MQTT messages, add optional support for escaped unicode characters, filtering of duplicate messages and installation as a systemd service

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ This project was created to create bridge between the Matrix Messenger and the M
 -----
 
 ## Setup
+Matrix-MQTT-Bridge can be run both via Docker or manually on the host as a systemd service
+
+### Via Docker
 You can run the Matrix-MQTT-Bridge via Docker, e.g. by using this `docker-compose.yaml` file. You will have to create a `config.ini` file to configure the connection to the MQTT broker and to the Matrix server. I'm using this project in combination with a **free private** [HiveMQ cloud instance](https://console.hivemq.cloud/), which acts as my MQTT broker.
 
 ```yaml
@@ -20,6 +23,20 @@ services:
     volumes:
       - ./config.ini:/config.ini
 ```
+
+### Via Systemd
+This repository includes an [example systemd unit file](matrix-mqtt-bridge.service) that allows to run the Matrix-MQTT-Bridge as a systemd service directly on the host. To use the systemd unit file, follow these steps:
+
+1. Clone the repository to `/opt/Matrix-MQTT-Bridge/`
+2. Install the `nio` and `paho` Python packages, e.g. using `pip` or your system package manager
+3. Copy the [`config.ini.example`](config.ini.example) to `config.ini` and fill in your configuration
+4. Copy the [`matrix-mqtt-bridge.service`](matrix-mqtt-bridge.service) to `/etc/systemd/system/`
+5. Create an unprivileged user `mqtt-bridge` (or edit the username in the [`matrix-mqtt-bridge.service`](matrix-mqtt-bridge.service))
+6. Optionally use `chown -R mqtt-bridge:mqtt-bridge /opt/Matrix-MQTT-Bridge` and `chmod 600 /opt/Matrix-MQTT-Bridge/config.ini` to protect your configuration from reading by other users
+7. Run `systemd daemon-reload` as root to add the new unit file to its index
+8. Run `systemctl enable --now matrix-mqtt-bridge` as root to start the bridge now and on each reboot
+9. Use `systemctl status matrix-mqtt-bridge` or `journalctl -eu matrix-mqtt-bridge` to view the log output of the bridge
+
 -----
 
 ## Config file

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ You will need two Matrix accounts: The one you are using on e.g. your phone (I'm
 Is actually self-explanatory. Enter your Host (for me it's my HiveMQ cloud instance), the port and the credentials to connect to the MQTT message broker (username / password).     
 - The `topic_sub` is the MQTT topic the Matrix-MQTT-Bridge will **subscribe** to. All MQTT messages recieved on this topic will be sent into the Matrix chatroom by the bridge.
 - When the Matrix-MQTT-Bridge recieves a message via Matrix, it will publish this message to the MQTT broker using the topic specified in `topic_pub`.
+- Enable `allow_escaped_unicode` to allow support for escaped unicode characters like `\u00fc` for german umlaut ü in the MQTT messages
+- Enable `filter_duplicates` to filter subsequent duplicate messages in MQTT (only the first will be forwarded to Matrix)
 
 ```ini
 [MATRIX]
@@ -67,4 +69,6 @@ port = 8883
 tls = true
 topic_sub = mqttbridge/sub
 topic_pub = mqttbridge/pub
+allow_escaped_unicode = false
+filter_duplicates = false
 ```

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Is actually self-explanatory. Enter your Host (for me it's my HiveMQ cloud insta
 - When the Matrix-MQTT-Bridge recieves a message via Matrix, it will publish this message to the MQTT broker using the topic specified in `topic_pub`.
 - Enable `allow_escaped_unicode` to allow support for escaped unicode characters like `\u00fc` for german umlaut ü in the MQTT messages
 - Enable `filter_duplicates` to filter subsequent duplicate messages in MQTT (only the first will be forwarded to Matrix)
+- Specify search and replace patterns by adding as many sections starting with `MQTT.replace.` as needed, each section containing a single search pattern and replacement regex
 
 ```ini
 [MATRIX]
@@ -71,4 +72,14 @@ topic_sub = mqttbridge/sub
 topic_pub = mqttbridge/pub
 allow_escaped_unicode = false
 filter_duplicates = false
+
+[MQTT.replace.remove_quotation_marks]
+# Remove all double quotation marks in message text before forwarding MQTT messages
+pattern = "
+substitution = 
+
+[MQTT.replace.charging_cant_start]
+# Prepend all messages containing "Cannot start charging" with a yellow warning sign emoji
+pattern = ^(.*Cannot start charging.*)
+substitution = ⚠️ \1
 ```

--- a/config.ini.example
+++ b/config.ini.example
@@ -14,3 +14,13 @@ topic_sub = mqttbridge/sub
 topic_pub = mqttbridge/pub
 allow_escaped_unicode = false
 filter_duplicates = false
+
+[MQTT.replace.remove_quotation_marks]
+# Remove all double quotation marks in message text before forwarding MQTT messages
+pattern = "
+substitution = 
+
+[MQTT.replace.charging_cant_start]
+# Prepend all messages containing "Cannot start charging" with a yellow warning sign emoji
+pattern = ^(.*Cannot start charging.*)
+substitution = ⚠️ \1

--- a/config.ini.example
+++ b/config.ini.example
@@ -12,3 +12,4 @@ port = 8883
 tls = true
 topic_sub = mqttbridge/sub
 topic_pub = mqttbridge/pub
+allow_escaped_unicode = false

--- a/config.ini.example
+++ b/config.ini.example
@@ -13,3 +13,4 @@ tls = true
 topic_sub = mqttbridge/sub
 topic_pub = mqttbridge/pub
 allow_escaped_unicode = false
+filter_duplicates = false

--- a/matrix-mqtt-bridge.service
+++ b/matrix-mqtt-bridge.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=A simple Matrix MQTT bridge
+After=network.target
+
+[Service]
+User=mqtt-bridge
+WorkingDirectory=/opt/Matrix-MQTT-Bridge/
+ExecStart=/usr/bin/python /opt/Matrix-MQTT-Bridge/matrix_mqtt_bridge.py
+
+[Install]
+WantedBy=multi-user.target

--- a/matrix_mqtt_bridge.py
+++ b/matrix_mqtt_bridge.py
@@ -2,6 +2,7 @@ import time
 import threading
 import asyncio
 import configparser 
+import re
 import nio
 import paho.mqtt.client as paho
 from paho import mqtt
@@ -92,10 +93,17 @@ def on_publish(client, userdata, mid, properties=None):
 def on_subscribe(client, userdata, mid, granted_qos, properties=None):
     print("[MQTT]", "Subscribed: " + str(mid) + " " + str(granted_qos))
 
+def unescapematch(match):
+    escapesequence = match.group(0)
+    digits = escapesequence[2:]
+    ordinal = int(digits, 16)
+    char = chr(ordinal)
+    return char
 
 # when a MQTT message is recieved
 def on_message(client, userdata, msg):
     message = msg.payload.decode("utf-8") 
+    message = re.sub(r'(\\u[0-9A-Fa-f]{2,4})', unescapematch, message)
     print("[MQTT]", msg.topic + " " + str(msg.qos) + " " + str(message))
 
     global matrix_client, event_loop

--- a/matrix_mqtt_bridge.py
+++ b/matrix_mqtt_bridge.py
@@ -30,8 +30,8 @@ mqtt_port = config.get("MQTT", "port")
 mqtt_tls = config.getboolean("MQTT", "tls")
 mqtt_topic_sub = config.get("MQTT", "topic_sub")
 mqtt_topic_pub = config.get("MQTT", "topic_pub")
-allow_escaped_unicode = config.get("MQTT", "allow_escaped_unicode")
-filter_duplicates = config.get("MQTT", "filter_duplicates")
+mqtt_allow_escaped_unicode = config.get("MQTT", "allow_escaped_unicode")
+mqtt_filter_duplicates = config.get("MQTT", "filter_duplicates")
 
 last_message = ""
 

--- a/matrix_mqtt_bridge.py
+++ b/matrix_mqtt_bridge.py
@@ -110,6 +110,15 @@ def on_message(client, userdata, msg):
     message = msg.payload.decode("utf-8") 
     if mqtt_allow_escaped_unicode:
         message = re.sub(r'(\\u[0-9A-Fa-f]{2,4})', unescapematch, message)
+    
+    for section in config.sections():
+        if section.startswith("MQTT.replace."):
+            replace_definition = config[section]
+            pattern = replace_definition.get("pattern", None)
+            substitution = replace_definition.get("substitution", None)
+            if pattern != None and substitution != None:
+                message = re.sub(pattern, substitution, message)
+    
     if not mqtt_filter_duplicates or message != last_message:
         last_message = message
         print("[MQTT]", msg.topic + " " + str(msg.qos) + " " + str(message))

--- a/matrix_mqtt_bridge.py
+++ b/matrix_mqtt_bridge.py
@@ -17,21 +17,21 @@ config = configparser.ConfigParser(interpolation=None)
 config.read("config.ini")
 
 # get matrix settings
-matrix_homeserver = config.get("MATRIX", "homeserver")
-matrix_user = config.get("MATRIX", "user")
-matrix_password = config.get("MATRIX", "password")
-matrix_room_id = config.get("MATRIX", "room_id")
+matrix_homeserver = config["MATRIX"].get("homeserver")
+matrix_user = config["MATRIX"].get("user")
+matrix_password = config["MATRIX"].get("password")
+matrix_room_id = config["MATRIX"].get("room_id")
 
 # get mqtt settings
-mqtt_host = config.get("MQTT", "host")
-mqtt_user = config.get("MQTT", "user")
-mqtt_password = config.get("MQTT", "password")
-mqtt_port = config.get("MQTT", "port")
+mqtt_host = config["MQTT"].get("host")
+mqtt_user = config["MQTT"].get("user")
+mqtt_password = config["MQTT"].get("password")
+mqtt_port = config["MQTT"].get("port")
 mqtt_tls = config.getboolean("MQTT", "tls")
-mqtt_topic_sub = config.get("MQTT", "topic_sub")
-mqtt_topic_pub = config.get("MQTT", "topic_pub")
-mqtt_allow_escaped_unicode = config.get("MQTT", "allow_escaped_unicode")
-mqtt_filter_duplicates = config.get("MQTT", "filter_duplicates")
+mqtt_topic_sub = config["MQTT"].get("topic_sub")
+mqtt_topic_pub = config["MQTT"].get("topic_pub")
+mqtt_allow_escaped_unicode = config["MQTT"].get("allow_escaped_unicode", False)
+mqtt_filter_duplicates = config["MQTT"].get("filter_duplicates", False)
 
 last_message = ""
 

--- a/matrix_mqtt_bridge.py
+++ b/matrix_mqtt_bridge.py
@@ -30,6 +30,7 @@ mqtt_port = config.get("MQTT", "port")
 mqtt_tls = config.getboolean("MQTT", "tls")
 mqtt_topic_sub = config.get("MQTT", "topic_sub")
 mqtt_topic_pub = config.get("MQTT", "topic_pub")
+allow_escaped_unicode = config.get("MQTT", "allow_escaped_unicode")
 
 async def message_callback(room: MatrixRoom, event: RoomMessageText) -> None:
     if room.room_id == matrix_room_id and event.sender != matrix_user and (int(time.time() * 1000) - event.server_timestamp) <= 30 * 1000:
@@ -103,7 +104,8 @@ def unescapematch(match):
 # when a MQTT message is recieved
 def on_message(client, userdata, msg):
     message = msg.payload.decode("utf-8") 
-    message = re.sub(r'(\\u[0-9A-Fa-f]{2,4})', unescapematch, message)
+    if allow_escaped_unicode:
+        message = re.sub(r'(\\u[0-9A-Fa-f]{2,4})', unescapematch, message)
     print("[MQTT]", msg.topic + " " + str(msg.qos) + " " + str(message))
 
     global matrix_client, event_loop

--- a/matrix_mqtt_bridge.py
+++ b/matrix_mqtt_bridge.py
@@ -61,7 +61,7 @@ async def main() -> None:
     # userdata is user defined data of any type, updated by user_data_set()
     # client_id is the given name of the client
     global mqtt_client
-    mqtt_client = paho.Client(client_id="Matrix-MQTT-Bridge", userdata=None, protocol=paho.MQTTv31)
+    mqtt_client = paho.Client(callback_api_version=paho.CallbackAPIVersion.VERSION1, client_id="Matrix-MQTT-Bridge", userdata=None, protocol=paho.MQTTv31)
     mqtt_client.on_connect = on_connect
     
     # enable TLS for secure MQTT connection
@@ -108,9 +108,9 @@ def unescapematch(match):
 def on_message(client, userdata, msg):
     global last_message
     message = msg.payload.decode("utf-8") 
-    if allow_escaped_unicode:
+    if mqtt_allow_escaped_unicode:
         message = re.sub(r'(\\u[0-9A-Fa-f]{2,4})', unescapematch, message)
-    if not filter_duplicates or message != last_message:
+    if not mqtt_filter_duplicates or message != last_message:
         last_message = message
         print("[MQTT]", msg.topic + " " + str(msg.qos) + " " + str(message))
         


### PR DESCRIPTION
Hi,
I implemented a fix with persistent messages, which arrive immediately when the MQTT client connects before the Matrix client had even a chance of connecting, by moving the MQTT client setup to the `main()` method as well.

Furthermore, I implemented three optional features:
- Allow escaped unicode characters like `\u00fc` for german umlaut ü in the MQTT message strings
- Filtering of subsequent duplicate messages
- Installation as a Systemd unit as an alternative to Docker

Feel free to give feedback or ask questions!
Lukaro